### PR TITLE
Fix - Incomplete regular expression for hostnames

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -20,7 +20,7 @@ const (
 	// RootDir is the path to the root directory
 	RootDir = "/"
 
-	//KanikoDir is the path to the Kaniko directory
+	// KanikoDir is the path to the Kaniko directory
 	KanikoDir = "/kaniko"
 
 	IgnoreListPath = "/proc/self/mountinfo"
@@ -76,8 +76,9 @@ const (
 var ScratchEnvVars = []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}
 
 // AzureBlobStorageHostRegEx is ReqEX for Valid azure blob storage host suffix in url for AzureCloud, AzureChinaCloud, AzureGermanCloud and AzureUSGovernment
-var AzureBlobStorageHostRegEx = []string{"https://(.+?).blob.core.windows.net/(.+)",
-	"https://(.+?).blob.core.chinacloudapi.cn/(.+)",
-	"https://(.+?).blob.core.cloudapi.de/(.+)",
-	"https://(.+?).blob.core.usgovcloudapi.net/(.+)",
+var AzureBlobStorageHostRegEx = []string{
+	"https://(.+?)\\.blob\\.core\\.windows\\.net/(.+)",
+	"https://(.+?)\\.blob\\.core\\.chinacloudapi\\.cn/(.+)",
+	"https://(.+?)\\.blob\\.core\\.cloudapi\\.de/(.+)",
+	"https://(.+?)\\.blob\\.core\\.usgovcloudapi\\.net/(.+)",
 }


### PR DESCRIPTION
Fixed the codeql issue
```
Sanitizing untrusted URLs is an important technique for preventing attacks such as request forgeries and malicious redirections. Often, this is done by checking that the host of a URL is in a set of allowed hosts.

If a regular expression implements such a check, it is easy to accidentally make the check too permissive by not escaping regular-expression meta-characters such as ..

Even if the check is not used in a security-critical context, the incomplete check may still cause undesirable behavior when it accidentally succeeds.

```

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Fixes #<issue number> _in case of a bug fix, this should point to a bug and any other related issue(s)_

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit tests and or integration tests added.


**Release Notes**

Describe any changes here so maintainer can include it in the release notes, or delete this block.

```
Examples of user facing changes:
- kaniko adds a new flag `--registry-repo` to override registry

```
